### PR TITLE
Raft was verified in Coq, not TLA+

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -667,7 +667,7 @@ consistency.
 - Paxos approaches independent decisions when what we *want* is state machines
   - Maintains a replicated *log* of state machine transitions instead
 - Also builds in cluster membership transitions, which is *key* for real systems
-- Very new, but we have a TLA+ proof of the core algorithm
+- Very new, but we have a Coq proof of the core algorithm
 - Can be used to write arbitrary sequential or linearizable state machines
   - RethinkDB
   - etcd


### PR DESCRIPTION
The Verdi project used the proof assistant Coq to verify Raft's core algorithm. Diego wrote a TLA+ spec for Raft (https://github.com/ongardie/raft.tla), but didn't manage to prove it correct. (He describes in his thesis that he verified a part of the protocol with the TLA proof system, but it grew too tedious.)

Of course, Verdi's proof didn't cover cluster membership changes, which is where the paper actually had a bug....
